### PR TITLE
Increase number of async spinners for ROS control

### DIFF
--- a/aria_driver/nodes/aria_ros_control_udp.cpp
+++ b/aria_driver/nodes/aria_ros_control_udp.cpp
@@ -13,7 +13,7 @@ int main(int argc, char **argv){
     RosControlUDP rosControlUDP;
     controller_manager::ControllerManager controllerManager(&rosControlUDP);
 
-    ros::AsyncSpinner spinner(1);
+    ros::AsyncSpinner spinner(2);
     spinner.start();
 
     ros::Time prev_time = ros::Time::now();


### PR DESCRIPTION
**Problem**:
```cpp
    ros::AsyncSpinner spinner(1);
```
provides insufficient spinning threads for the `controller_manager` during startup. I get deterministic freezes, when loading and running ROS-controllers directly during startup with this control_node.

**Solution**:
Increasing the number of async threads solves the issue.

I remember that I saw the recommendation of at least `2` threads in some ROS-control tutorial or wikipage, but am not able to find it at the moment.
